### PR TITLE
Improve email module and fix play button overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,10 @@ Options:
 
 #### `mb_email_embed` (experimental)
 Renders an email appropriate player based on the oEmbed thumbnail, essentially a linked image without JS/CSS dependencies.
-It will show a poster image based on the oembed thumbnail, linked to the oembed_url by default but possible to override.
+It will show a poster image based on the oembed thumbnail, linked to the oembed_url by default but possible to override with an image from Files.
+When a custom poster URL is selected, a play button of a specific color can be overlayed on it as well.
+
+*Note* Currently the module must link to a CMS page where the MB media is embedded in order to track play events.
 
 ```
 mb_email_embed(embed_field, options) %}

--- a/mb-email-embed.module/fields.json
+++ b/mb-email-embed.module/fields.json
@@ -49,6 +49,13 @@
     "required": false,
     "locked": false,
     "type": "color",
+    "visibility": {
+      "controlling_field": "custom_poster_enabled",
+      "controlling_value_regex": "true",
+      "operator": "EQUAL",
+      "access": null,
+      "hidden_subfields": null
+    },
     "default": {
       "color": "",
       "opacity": 100

--- a/mb-hubl-macros.html
+++ b/mb-hubl-macros.html
@@ -45,32 +45,20 @@
   {% set field_value = embed_field.source_type == "media_bridge" ? embed_field.media_bridge_object : embed_field %}
   {% set oembed_response = field_value.oembed_response %}
   {% set link_url = options.link_url || field_value.oembed_url %}
-  {% set poster_url = options.poster_url || oembed_response.thumbnail_url || oembed_response.url %}
+  {% set img_alt = oembed_response.title %}
+  {% set max_container_width = current_column_content_width is number ? current_column_content_width : email_body_width|default(600) %}
+
   {% if oembed_response.type == "photo" && oembed_response.url %}
-    <img src="{{ oembed_response.url }}" />
+    <img alt="{{ img_alt }}" src="{{ oembed_response.url }}" />
   {% else if oembed_response.html %}
+    {% set img_url = options.poster_url && options.play_button_color ? video_thumbnail({ url: options.poster_url, color: options.play_button_color, width: max_container_width }) : options.poster_url || oembed_response.thumbnail_url %}
     <div class="hs-mb-embed-wrapper"
          style="position: relative; {% if field_value.size_type == 'exact' %}width: {{ field_value.width }}px; height: {{ field_value.height }}px;{% endif %}">
       <a href="{{ link_url }}" target="_blank">
-        <img class="hs-mb-embed-placeholder" src="{{ poster_url }}" style="max-width: 100%; max-height: 100%;"/>
-        {% if options.play_button_color %}
-          {{ mb_play_button(options.play_button_color) }}
-        {% endif %}
+        <img alt="{{ img_alt }}" class="hs-mb-embed-placeholder" src="{{ img_url }}" style="max-width: 100%; max-height: 100%;"/>
       </a>
     </div>
   {% else %}
     <p>{{ oembed_type_error }}</p>
   {% endif %}
-{% endmacro %}
-
-{% macro mb_play_button(color) %}
-  {% set color = color || 'white' %}
-  <div class="play-button hs-mb-embed-placeholder"
-       style="position: absolute; top: 0; left: 0; height: 100%; width: 100%; align-items: center; cursor: pointer; display: flex; justify-content: center">
-    <svg viewBox="0 0 80 80"
-         style="display: block; height: auto; width: 20%; max-width: 120px; max-height: 120px; filter: drop-shadow(0 0 1rem #666)">
-      <circle cx="41" cy="41" r="37" stroke="{{ color }}" stroke-width="5" fill="none"></circle>
-      <polygon fill="{{ color }}" stroke="{{ color }}" stroke-width="5" points="32,25 32,58 60,42"></polygon>
-    </svg>
-  </div>
 {% endmacro %}


### PR DESCRIPTION
Absolute positioning is not possible in many email clients so the SVG overlay strategy is not going to work. Instead, using the `video_thumbnail` HubL function and clarifying selecting a custom poster image is required (it only works on FM files). Also adding alt text, and starting to support dimensions more like the default Video email module.

Including a README note about "experimental" status and current state of play events as well