### PR TITLE
Rework email module to avoid macro import

### DIFF
--- a/src/mb-email-embed.module/fields.json
+++ b/src/mb-email-embed.module/fields.json
@@ -12,56 +12,6 @@
     }
   },
   {
-    "id": "custom_poster_enabled",
-    "name": "custom_poster_enabled",
-    "label": "Custom Poster Enabled",
-    "required": false,
-    "locked": false,
-    "display": "checkbox",
-    "type": "boolean",
-    "default": false
-  },
-  {
-    "name": "custom_poster",
-    "label": "Custom Poster",
-    "required": false,
-    "locked": false,
-    "visibility": {
-      "controlling_field": "custom_poster_enabled",
-      "controlling_value_regex": "true",
-      "operator": "EQUAL",
-      "access": null,
-      "hidden_subfields": null
-    },
-    "responsive": true,
-    "resizable": false,
-    "show_loading": false,
-    "type": "image",
-    "default": {
-      "src": "",
-      "alt": null,
-      "loading": "lazy"
-    }
-  },
-  {
-    "name": "play_button_color",
-    "label": "Play button color",
-    "required": false,
-    "locked": false,
-    "type": "color",
-    "visibility": {
-      "controlling_field": "custom_poster_enabled",
-      "controlling_value_regex": "true",
-      "operator": "EQUAL",
-      "access": null,
-      "hidden_subfields": null
-    },
-    "default": {
-      "color": "",
-      "opacity": 100
-    }
-  },
-  {
     "id": "custom_link_enabled",
     "name": "custom_link_enabled",
     "label": "Custom Link Enabled",
@@ -89,6 +39,52 @@
       "content_id": null,
       "href": "",
       "type": "EXTERNAL"
+    }
+  },
+  {
+    "id": "custom_poster_enabled",
+    "name": "custom_poster_enabled",
+    "label": "Custom Poster Enabled",
+    "required": false,
+    "locked": false,
+    "display": "checkbox",
+    "type": "boolean",
+    "default": false
+  },
+  {
+    "id": "custom_poster",
+    "name": "custom_poster",
+    "label": "Custom Poster",
+    "required": false,
+    "locked": false,
+    "responsive": false,
+    "resizable": false,
+    "show_loading": false,
+    "type": "image",
+    "visibility": {
+      "controlling_field": "custom_poster_enabled",
+      "controlling_value_regex": "true",
+      "operator": "EQUAL",
+      "access": null,
+      "hidden_subfields": null
+    }
+  },
+  {
+    "name": "play_button_color",
+    "label": "Play button color",
+    "required": false,
+    "locked": false,
+    "type": "color",
+    "visibility": {
+      "controlling_field": "custom_poster_enabled",
+      "controlling_value_regex": "true",
+      "operator": "EQUAL",
+      "access": null,
+      "hidden_subfields": null
+    },
+    "default": {
+      "color": "",
+      "opacity": 100
     }
   }
 ]

--- a/src/mb-email-embed.module/module.html
+++ b/src/mb-email-embed.module/module.html
@@ -1,11 +1,51 @@
-{% from '/media-bridge/mb-hubl-macros.html' import mb_email_embed, no_selected_media_error %}
+{% macro mb_email_embed(embed_field, options) %}
+  {% set field_value = embed_field.source_type == "media_bridge" ? embed_field.media_bridge_object : embed_field %}
+  {% set oembed_response = field_value.oembed_response %}
+  {% set link_url = options.link_url || field_value.oembed_url %}
+  {% set img_alt = oembed_response.title %}
+  {% set img_src = oembed_response.thumbnail_url %}
+  {% if oembed_response.type == "photo" && oembed_response.url %}
+    {% set img_src = oembed_response.url %}
+  {% endif %}
+  {% set max_body_width = current_column_content_width is number ? current_column_content_width : email_body_width|default(600) %}
+
+  {% set img_width = field_value.width %}
+  {% if current_column_content_width is number && current_column_content_width < img_width %}
+    {% set img_width = max_body_width %}
+  {% endif %}
+
+  {% if options.custom_poster.src %}
+    {% set img_src = options.custom_poster.src %}
+    {% if options.play_button_color %}
+      {% set img_src = video_thumbnail({ url: img_src, color: options.play_button_color, width: img_width }) %}
+    {% endif %}
+    {% if options.custom_poster.alt %}
+      {% set img_alt = options.custom_poster.alt %}
+    {% endif %}
+  {% endif %}
+
+  {% if img_src %}
+    <table class="hse-image-wrapper hs-mb-email-embed" role="presentation" width="100%" cellpadding="0" cellspacing="0">
+      <tbody>
+        <tr>
+          <td style="{{ wrapper_css }}">
+            <a href="{{ link_url }}" target="_blank">
+              <img alt="{{ img_alt }}" src="{{ img_src }}" width="{{ img_width }}" style="max-width: 100%;" />
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  {% endif %}
+{% endmacro %}
+
 
 {% if module.embed_field.media_bridge_object.oembed_url %}
   {{ mb_email_embed(module.embed_field, {
-    link_url: module.custom_link_url.href,
-    poster_url: module.custom_poster.src,
+    link_url: module.custom_link_enabled ? module.custom_link_url.href : none,
+    custom_poster: module.custom_poster_enabled ? module.custom_poster : none,
     play_button_color: module.play_button_color.color,
   }) }}
 {% else %}
-  <div>{{ no_selected_media_error }}</div>
+  <p>Select Media Bridge media to display.</p>
 {% endif %}


### PR DESCRIPTION
- inline macro since `{% import %}` is problematic for MB module delivery
- follow precedent of default email image/video modules more closely as far as markup/sizing. padding control supported, and makes alignment support feasible
- only set height on image to avoid skewing, and max sure it does not outgrow body
- allow customizing image alt when overriding poster image, more reliable video_thumbnail usage

<img width="381" alt="Screen Shot 2021-05-14 at 7 53 58 PM" src="https://user-images.githubusercontent.com/455026/118341733-376c6980-b4ee-11eb-99a7-196be5a54460.png">
<img width="434" alt="Screen Shot 2021-05-14 at 7 54 59 PM" src="https://user-images.githubusercontent.com/455026/118341747-48b57600-b4ee-11eb-9c97-d1a08cc467bb.png">

cc @semanticart 