### PR TITLE
Add module demonstrating render_modes for new tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ When a custom poster image is selected, a play button of a specific color can be
 
 *Note* Currently the module must link to a HubSpot CMS page where the MB media is embedded in order to track play events.
 
-### `media_bridge_embed` HubL Tag :new:
-Renders a player based on the MB media selected for an Embed field, and will include the `media-bridge-embed-js` helper script automatically.
+### `media_bridge_embed` HubL Tag
+:new: Renders a player based on the MB media selected for an Embed field, and will include the `media-bridge-embed-js` helper script automatically.
 
 ```
 {% media_bridge_embed %}

--- a/docs/media-bridge-embed-js.md
+++ b/docs/media-bridge-embed-js.md
@@ -1,14 +1,14 @@
 # media-bridge-embed-js
 
 Helper JS for rendering Media Bridge embeds.
-[The `hubspotutk` cookie](https://developers.hubspot.com/docs/api/events/tracking-code) will be added as the `?hs_utk` query param to player `iframe`s if available.
-
+[The `hubspotutk` cookie](https://developers.hubspot.com/docs/api/events/tracking-code) will be added to the iframe URL as the `?hs_utk` query param if available.
+The `?hs_portal_id` query param will also be included to allow tracking a play event.
 
 ## Alternatives
 For a Media Bridge integration which is not based on `iframe` players, we recommend including a third party script to utilize the `hubspotutk` cookie for tracking play events.
 
 ## Installation
-Add this to a custom module. This is automatic if using the `mb_embed` macro
+Add this to a custom module. This is automatic if using [the `media_bridge_embed` HubL tag](../README.md#media_bridge_embed-hubl-tag) (recommended).
 ```
 {{ require_js('https://static.hsappstatic.net/media-bridge-embed-js/ex/v1.js' }}
 ```

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "upload-crm-object": "hs upload src/crm-object.module media-bridge/crm-object.module",
     "upload-embed-field": "hs upload src/embed-field-with-mb.module media-bridge/embed-field-with-mb.module",
-    "upload": "hs upload src/mb-embed.module media-bridge/mb-embed.module && hs upload src/mb-email-embed.module media-bridge/mb-email-embed.module && yarn upload-crm-object && yarn upload-embed-field"
+    "upload-render-modes": "hs upload src/mb-render-modes.module media-bridge/mb-render-modes.module",
+    "upload": "hs upload src/mb-embed.module media-bridge/mb-embed.module && hs upload src/mb-email-embed.module media-bridge/mb-email-embed.module && yarn upload-crm-object && yarn upload-embed-field && yarn upload-render-modes"
   },
   "devDependencies": {
     "@hubspot/cms-cli": "^2.2.3"

--- a/src/crm-object.module/fields.json
+++ b/src/crm-object.module/fields.json
@@ -3,6 +3,8 @@
     "name": "embed_field",
     "label": "Media",
     "supported_source_types": ["media_bridge"],
+    "show_preview": false,
+    "resizable": false,
     "type": "embed"
   }
 ]

--- a/src/crm-object.module/module.html
+++ b/src/crm-object.module/module.html
@@ -3,17 +3,17 @@
   {% set object_type_suffix = '_Videos' %}
   {% if embed_field_value.media_type == 'IMAGE' %}
     {% set object_type_suffix = '_Images' %}
-  {% else if embed_field_value.media_type == 'AUDIO' %}
+  {% elif embed_field_value.media_type == 'AUDIO' %}
     {% set object_type_suffix = '_Audio' %}
   {% endif %}
-  {% set object_type = 'a' + embed_field_value.provider_id + object_type_suffix %}
+  {% set object_type = 'a' ~ embed_field_value.provider_id ~ object_type_suffix %}
   {% set media_object = crm_object(object_type, embed_field_value.id, "hs_title,hs_oembed_url,hs_file_url,hs_thumbnail_url,hs_poster_url,hs_details_page_link") %}
 
   {% if media_object %}
     <div>
       <h3>{{ media_object.hs_title }}</h3>
-      {% if crm_object.hs_thumbnail_url %}
-        <img src="{{ crm_object.hs_thumbnail_url }}" />
+      {% if media_object.hs_thumbnail_url %}
+        <img src="{{ media_object.hs_thumbnail_url }}" />
       {% endif %}
       <pre>CRM object: {{ media_object|pprint }}</pre>
     </div>

--- a/src/mb-email-embed.module/fields.json
+++ b/src/mb-email-embed.module/fields.json
@@ -75,6 +75,7 @@
     "required": false,
     "locked": false,
     "type": "color",
+    "inline_help_text": "Only works for images in Files via custom_poster",
     "visibility": {
       "controlling_field": "custom_poster_enabled",
       "controlling_value_regex": "true",

--- a/src/mb-email-embed.module/module.html
+++ b/src/mb-email-embed.module/module.html
@@ -1,14 +1,16 @@
 {% macro mb_email_embed(embed_field, options) %}
-  {% set field_value = embed_field.source_type == "media_bridge" ? embed_field.media_bridge_object : embed_field %}
-  {% set oembed_response = field_value.oembed_response %}
+  {% set field_value = embed_field.media_bridge_object %}
   {% set link_url = options.link_url || field_value.oembed_url %}
+
+  {# try to fetch refresh oembed response, fallback to persisted field value if oembed() returns nothing #}
+  {% set oembed_response = oembed({ url: embed_field.media_bridge_object.oembed_url }) || field_value.oembed_response %}
   {% set img_alt = oembed_response.title %}
   {% set img_src = oembed_response.thumbnail_url %}
   {% if oembed_response.type == "photo" && oembed_response.url %}
     {% set img_src = oembed_response.url %}
   {% endif %}
-  {% set max_body_width = current_column_content_width is number ? current_column_content_width : email_body_width|default(600) %}
 
+  {% set max_body_width = current_column_content_width is number ? current_column_content_width : email_body_width|default(600) %}
   {% set img_width = field_value.width %}
   {% if current_column_content_width is number && current_column_content_width < img_width %}
     {% set img_width = max_body_width %}
@@ -39,13 +41,12 @@
   {% endif %}
 {% endmacro %}
 
-
 {% if module.embed_field.media_bridge_object.oembed_url %}
   {{ mb_email_embed(module.embed_field, {
-    link_url: module.custom_link_enabled ? module.custom_link_url.href : none,
-    custom_poster: module.custom_poster_enabled ? module.custom_poster : none,
+    link_url: module.custom_link_enabled ? module.custom_link_url.href : null,
+    custom_poster: module.custom_poster_enabled ? module.custom_poster : null,
     play_button_color: module.play_button_color.color,
   }) }}
 {% else %}
-  <p>Select Media Bridge media to display.</p>
+  <p>The `embed_field` must have a Media Bridge object selected to display.</p>
 {% endif %}

--- a/src/mb-embed.module/fields.json
+++ b/src/mb-embed.module/fields.json
@@ -6,17 +6,7 @@
     "locked": false,
     "supported_source_types": ["media_bridge"],
     "supported_media_bridge_providers": [],
-    "type": "embed",
-    "default": {
-      "source_type": "media_bridge",
-      "media_bridge_object": {
-        "id": null,
-        "oembed_url": "",
-        "provider_id": null,
-        "oembed_response": {},
-        "size_type": "auto"
-      }
-    }
+    "type": "embed"
   },
   {
     "name": "custom_poster",
@@ -26,12 +16,6 @@
     "responsive": true,
     "resizable": false,
     "show_loading": false,
-    "type": "image",
-    "default": {
-      "size_type": "auto",
-      "src": "",
-      "alt": null,
-      "loading": "disabled"
-    }
+    "type": "image"
   }
 ]

--- a/src/mb-embed.module/module.css
+++ b/src/mb-embed.module/module.css
@@ -4,15 +4,13 @@
   max-width: 100%;
 }
 
-.hs-examples .hs-mb-embed-wrapper[data-size-type="auto_custom_max"] .hs-mb-iframe-wrapper,
-.hs-examples .hs-mb-embed-wrapper[data-size-type="auto_full_width"] .hs-mb-iframe-wrapper {
+.hs-examples .hs-mb-iframe-wrapper {
   height: 0;
   padding-bottom: 56.25%;
   position: relative;
 }
 
-.hs-examples .hs-mb-embed-wrapper[data-size-type="auto_custom_max"] .hs-mb-iframe-wrapper iframe,
-.hs-examples .hs-mb-embed-wrapper[data-size-type="auto_full_width"] .hs-mb-iframe-wrapper iframe {
+.hs-examples .hs-mb-iframe-wrapper iframe {
   position: absolute;
   width: 100%;
   height: 100%;

--- a/src/mb-embed.module/module.html
+++ b/src/mb-embed.module/module.html
@@ -7,6 +7,6 @@
       reveal_on={{ module.custom_poster.src ? 'click' : 'load' }}
     %}
   {% else %}
-    <p>The `embed_field` parameter must have a Media Bridge object selected to display.</p>
+    <p>The `embed_field` must have a Media Bridge object selected to display.</p>
   {% endif %}
 </div>

--- a/src/mb-render-modes.module/fields.json
+++ b/src/mb-render-modes.module/fields.json
@@ -1,0 +1,37 @@
+[
+  {
+    "name": "embed_field",
+    "label": "Media",
+    "required": false,
+    "locked": false,
+    "supported_source_types": [
+      "media_bridge"
+    ],
+    "supported_media_bridge_providers": [],
+    "show_preview": false,
+    "resizable": false,
+    "type": "embed"
+  },
+  {
+    "type": "choice",
+    "display": "select",
+    "choices": [
+      [
+        "cached",
+        "cached"
+      ],
+      [
+        "eager",
+        "eager"
+      ],
+      [
+        "refetch",
+        "refetch"
+      ]
+    ],
+    "label": "Render mode",
+    "inline_help_text": "Demonstrates media_bridge_embed tag's `render_mode` param.",
+    "name": "render_mode",
+    "default": "cached"
+  }
+]

--- a/src/mb-render-modes.module/meta.json
+++ b/src/mb-render-modes.module/meta.json
@@ -3,5 +3,5 @@
   "icon": "fontawesome-5.14.0:Play%20Circle:SOLID",
   "host_template_types": ["PAGE", "BLOG_POST", "BLOG_LISTING"],
   "label": "[Media Bridge Examples] Render modes",
-  "is_available_for_new_content": false
+  "is_available_for_new_content": true
 }

--- a/src/mb-render-modes.module/meta.json
+++ b/src/mb-render-modes.module/meta.json
@@ -1,0 +1,7 @@
+{
+  "global": false,
+  "icon": "fontawesome-5.14.0:Play%20Circle:SOLID",
+  "host_template_types": ["PAGE", "BLOG_POST", "BLOG_LISTING"],
+  "label": "[Media Bridge Examples] Render modes",
+  "is_available_for_new_content": false
+}

--- a/src/mb-render-modes.module/module.html
+++ b/src/mb-render-modes.module/module.html
@@ -1,0 +1,8 @@
+{% if module.embed_field.media_bridge_object.oembed_url %}
+  {% media_bridge_embed
+    media_bridge_object={{ module.embed_field.media_bridge_object }}
+    render_mode={{ module.render_mode }}
+  %}
+{% else %}
+  <p>The `embed_field` parameter must have a Media Bridge object selected to display.</p>
+{% endif %}


### PR DESCRIPTION
A new module to show how the 3 `render_mode` param values work, to assist when provider seek to fetch the oembed url every pageload.

- improve email module to fetch fresh response via `oembed()` HubL function
- document `?hs_portal_id` query param in helper JS doc, link to section on hubl tag instead of macro we removed
- simplify fields and CSS in page embed module
- use `{% elif %}` to properly formulate the object_type for `crm_object` exampleand use new capability to hide preview and 

cc @semanticart @jmagnarelli-hs 